### PR TITLE
Add `--format` flag to freta CLI for imageList and artifactList operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "itoa",
+ "itoa 1.0.5",
  "matchit",
  "memchr",
  "mime",
@@ -291,6 +291,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +374,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "cli-table"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adfbb116d9e2c4be7011360d0c0bee565712c11e969c9609b25b619366dc379d"
+dependencies = [
+ "cli-table-derive",
+ "csv",
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "cli-table-derive"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af3bfb9da627b0a6c467624fb7963921433774ed435493b5c08a3053e829ad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -438,6 +473,28 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa 0.4.8",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -628,6 +685,7 @@ dependencies = [
  "azure_storage_blobs",
  "bytes",
  "clap",
+ "cli-table",
  "env_logger",
  "futures",
  "getrandom 0.2.8",
@@ -881,7 +939,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 1.0.5",
 ]
 
 [[package]]
@@ -954,7 +1012,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 1.0.5",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1088,6 +1146,12 @@ dependencies = [
  "rustix",
  "windows-sys",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -1561,6 +1625,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1773,7 +1843,7 @@ version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
- "itoa",
+ "itoa 1.0.5",
  "ryu",
  "serde",
 ]
@@ -1805,7 +1875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 1.0.5",
  "ryu",
  "serde",
 ]
@@ -1969,7 +2039,7 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
- "itoa",
+ "itoa 1.0.5",
  "libc",
  "num_threads",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ tokio = {version="1.25", features=["full"], optional=true}
 uuid = {version="1.2", features=["serde"]}
 hmac = {version="0.12", optional=true}
 sha2 = {version="0.10", optional=true}
+cli-table = {version = "0.4"}
 
 [dev-dependencies]
 azure_mgmt_compute = "0.9"

--- a/examples/analyze-az-vm.rs
+++ b/examples/analyze-az-vm.rs
@@ -39,6 +39,7 @@ struct Args {
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    info!("!----------------------------starting");
     let cmd = Args::parse();
 
     let mut client = Client::new().await?;
@@ -46,12 +47,14 @@ async fn main() -> Result<()> {
     let creds = Arc::new(DefaultAzureCredential::default());
     let compute_client = azure_mgmt_compute::Client::builder(creds).build();
 
+    info!("!----------------------------getting vm information");
     let vm = compute_client
         .virtual_machines_client()
         .get(&cmd.group, &cmd.vm_name, &cmd.subscription_id)
         .into_future()
         .await?;
 
+    info!("!----------------------------got vm information xxxx");
     let mut tags = cmd.tags.unwrap_or_default();
     tags.push(("name".to_string(), cmd.vm_name.clone()));
     tags.push(("group".to_string(), cmd.group.clone()));

--- a/examples/analyze-az-vm.rs
+++ b/examples/analyze-az-vm.rs
@@ -39,7 +39,6 @@ struct Args {
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
-    info!("!----------------------------starting");
     let cmd = Args::parse();
 
     let mut client = Client::new().await?;
@@ -47,14 +46,12 @@ async fn main() -> Result<()> {
     let creds = Arc::new(DefaultAzureCredential::default());
     let compute_client = azure_mgmt_compute::Client::builder(creds).build();
 
-    info!("!----------------------------getting vm information");
     let vm = compute_client
         .virtual_machines_client()
         .get(&cmd.group, &cmd.vm_name, &cmd.subscription_id)
         .into_future()
         .await?;
 
-    info!("!----------------------------got vm information xxxx");
     let mut tags = cmd.tags.unwrap_or_default();
     tags.push(("name".to_string(), cmd.vm_name.clone()));
     tags.push(("group".to_string(), cmd.group.clone()));

--- a/src/bin/freta.rs
+++ b/src/bin/freta.rs
@@ -8,9 +8,9 @@ use freta::{
     Client, ClientId, Config, Error, ImageFormat, ImageId, ImageState, OwnerId, Result, Secret,
 };
 use freta_io::{
-    csv::{artifact_list_to_csv, image_list_to_csv},
-    json::{artifact_list_to_json, image_list_to_json},
-    table::{artifact_list_to_table, image_list_to_table},
+    csv::{from_artifacts as csv_from_artifacts, from_images as csv_from_images},
+    json::{from_artifacts as json_from_artifacts, from_images as json_from_images},
+    table::{from_artifacts as table_from_artifacts, from_images as table_from_images},
 };
 use futures::StreamExt;
 use log::info;
@@ -360,9 +360,9 @@ async fn artifacts(opts: ArtifactsCmd) -> Result<()> {
             let mut stream = client.artifacts_list(opts.image_id);
 
             match opts.format {
-                Some(OutputFormat::Table) => artifact_list_to_table(&mut stream).await?,
-                Some(OutputFormat::CSV) => artifact_list_to_csv(&mut stream).await?,
-                _ => artifact_list_to_json(&mut stream).await?,
+                Some(OutputFormat::Table) => table_from_artifacts(&mut stream).await?,
+                Some(OutputFormat::CSV) => csv_from_artifacts(&mut stream).await?,
+                _ => json_from_artifacts(&mut stream).await?,
             }
         }
         ArtifactsCommands::Get(opts) => {
@@ -404,9 +404,9 @@ async fn images(images_opts: ImagesCmd) -> Result<()> {
             );
 
             match image_list.format {
-                Some(OutputFormat::Table) => image_list_to_table(&mut stream).await?,
-                Some(OutputFormat::CSV) => image_list_to_csv(&mut stream).await?,
-                _ => image_list_to_json(&mut stream).await?,
+                Some(OutputFormat::Table) => table_from_images(&mut stream).await?,
+                Some(OutputFormat::CSV) => csv_from_images(&mut stream).await?,
+                _ => json_from_images(&mut stream).await?,
             }
             Ok(())
         }

--- a/src/bin/freta_io/csv.rs
+++ b/src/bin/freta_io/csv.rs
@@ -1,0 +1,29 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+use freta::{Image, Result};
+use futures::{Stream, StreamExt};
+use std::pin::Pin;
+
+pub async fn image_list_to_csv(
+    stream: &mut Pin<Box<impl Stream<Item = std::result::Result<Image, crate::Error>>>>,
+) -> Result<()> {
+    print!("image_id,owner_id,state,format\n");
+    while let Some(image) = stream.next().await {
+        let image: Image = image?;
+        print!(
+            "{},{},{},{}\n",
+            image.image_id, image.owner_id, image.state, image.format
+        );
+    }
+    Ok(())
+}
+
+pub async fn artifact_list_to_csv(
+    stream: &mut Pin<Box<impl Stream<Item = std::result::Result<String, crate::Error>>>>,
+) -> Result<()> {
+    print!("artifact\n");
+    while let Some(artifact) = stream.next().await {
+        let artifact: String = artifact?;
+        print!("{}\n", artifact)
+    }
+    Ok(())
+}

--- a/src/bin/freta_io/csv.rs
+++ b/src/bin/freta_io/csv.rs
@@ -3,27 +3,27 @@ use freta::{Image, Result};
 use futures::{Stream, StreamExt};
 use std::pin::Pin;
 
-pub async fn image_list_to_csv(
+pub async fn from_images(
     stream: &mut Pin<Box<impl Stream<Item = std::result::Result<Image, crate::Error>>>>,
 ) -> Result<()> {
-    print!("image_id,owner_id,state,format\n");
+    println!("image_id,owner_id,state,format");
     while let Some(image) = stream.next().await {
         let image: Image = image?;
-        print!(
-            "{},{},{},{}\n",
+        println!(
+            "{},{},{},{}",
             image.image_id, image.owner_id, image.state, image.format
         );
     }
     Ok(())
 }
 
-pub async fn artifact_list_to_csv(
+pub async fn from_artifacts(
     stream: &mut Pin<Box<impl Stream<Item = std::result::Result<String, crate::Error>>>>,
 ) -> Result<()> {
-    print!("artifact\n");
+    println!("artifact");
     while let Some(artifact) = stream.next().await {
         let artifact: String = artifact?;
-        print!("{}\n", artifact)
+        println!("{artifact}");
     }
     Ok(())
 }

--- a/src/bin/freta_io/json.rs
+++ b/src/bin/freta_io/json.rs
@@ -1,0 +1,42 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+use std::pin::Pin;
+
+use futures::{Stream, StreamExt};
+use serde::ser::{SerializeSeq, Serializer};
+
+use freta::{Image, Result};
+
+pub async fn image_list_to_json(
+    stream: &mut Pin<Box<impl Stream<Item = std::result::Result<Image, crate::Error>>>>,
+) -> Result<()> {
+    // page through results, and build a ImagesListResponse-like output (JSON)
+    // by hand.  This is a bit of a hack, but this allows us to not have
+    // to coalesce all of the images_list calls in memory before
+    // serializing the output.
+    print!("{{\"images\":");
+    let mut ser = serde_json::Serializer::new(std::io::stdout());
+    let mut serializer = ser.serialize_seq(None)?;
+    while let Some(image) = stream.next().await {
+        let image = image?;
+        serializer.serialize_element(&image)?;
+    }
+    serializer.end()?;
+    println!("}}");
+    Ok(())
+}
+
+pub async fn artifact_list_to_json(
+    stream: &mut Pin<Box<impl Stream<Item = std::result::Result<String, crate::Error>>>>,
+) -> Result<()> {
+    // page through results, and build a JSON output by hand.  This is a
+    // bit of a hack, but this allows us to not have to coalesce all of
+    // the images_list calls in memory before serializing the output.
+    let mut ser = serde_json::Serializer::new(std::io::stdout());
+    let mut serializer = ser.serialize_seq(None)?;
+    while let Some(name) = stream.next().await {
+        let name = name?;
+        serializer.serialize_element(&name)?;
+    }
+    serializer.end()?;
+    Ok(())
+}

--- a/src/bin/freta_io/json.rs
+++ b/src/bin/freta_io/json.rs
@@ -6,7 +6,7 @@ use serde::ser::{SerializeSeq, Serializer};
 
 use freta::{Image, Result};
 
-pub async fn image_list_to_json(
+pub async fn from_images(
     stream: &mut Pin<Box<impl Stream<Item = std::result::Result<Image, crate::Error>>>>,
 ) -> Result<()> {
     // page through results, and build a ImagesListResponse-like output (JSON)
@@ -25,7 +25,7 @@ pub async fn image_list_to_json(
     Ok(())
 }
 
-pub async fn artifact_list_to_json(
+pub async fn from_artifacts(
     stream: &mut Pin<Box<impl Stream<Item = std::result::Result<String, crate::Error>>>>,
 ) -> Result<()> {
     // page through results, and build a JSON output by hand.  This is a

--- a/src/bin/freta_io/mod.rs
+++ b/src/bin/freta_io/mod.rs
@@ -1,0 +1,4 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+pub mod csv;
+pub mod json;
+pub mod table;

--- a/src/bin/freta_io/table.rs
+++ b/src/bin/freta_io/table.rs
@@ -1,0 +1,51 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+use std::pin::Pin;
+
+use cli_table::{print_stdout, Cell, CellStruct, Style, Table};
+use futures::{Stream, StreamExt};
+
+use freta::{Image, Result};
+
+pub async fn image_list_to_table(
+    stream: &mut Pin<Box<impl Stream<Item = std::result::Result<Image, crate::Error>>>>,
+) -> Result<()> {
+    let mut table: Vec<Vec<CellStruct>> = Vec::new();
+    while let Some(image) = stream.next().await {
+        let image: Image = image?;
+        table.push(vec![
+            image.image_id.cell(),
+            image.owner_id.cell(),
+            image.state.cell(),
+            image.format.cell(),
+        ]);
+    }
+    let table = table
+        .table()
+        .title(vec![
+            "Image ID".cell().bold(true),
+            "Owner ID".cell().bold(true),
+            "State".cell().bold(true),
+            "Format".cell().bold(true),
+        ])
+        .bold(true);
+
+    assert!(print_stdout(table).is_ok());
+    Ok(())
+}
+
+pub async fn artifact_list_to_table(
+    stream: &mut Pin<Box<impl Stream<Item = std::result::Result<String, crate::Error>>>>,
+) -> Result<()> {
+    let mut table: Vec<Vec<CellStruct>> = Vec::new();
+    while let Some(artifact) = stream.next().await {
+        let artifact: String = artifact?;
+        table.push(vec![artifact.cell()]);
+    }
+    let table = table
+        .table()
+        .title(vec!["Artifact".cell().bold(true)])
+        .bold(true);
+
+    assert!(print_stdout(table).is_ok());
+    Ok(())
+}

--- a/src/bin/freta_io/table.rs
+++ b/src/bin/freta_io/table.rs
@@ -6,7 +6,7 @@ use futures::{Stream, StreamExt};
 
 use freta::{Image, Result};
 
-pub async fn image_list_to_table(
+pub async fn from_images(
     stream: &mut Pin<Box<impl Stream<Item = std::result::Result<Image, crate::Error>>>>,
 ) -> Result<()> {
     let mut table: Vec<Vec<CellStruct>> = Vec::new();
@@ -33,7 +33,7 @@ pub async fn image_list_to_table(
     Ok(())
 }
 
-pub async fn artifact_list_to_table(
+pub async fn from_artifacts(
     stream: &mut Pin<Box<impl Stream<Item = std::result::Result<String, crate::Error>>>>,
 ) -> Result<()> {
     let mut table: Vec<Vec<CellStruct>> = Vec::new();

--- a/src/models/base.rs
+++ b/src/models/base.rs
@@ -8,7 +8,7 @@ use std::{
     fmt::{Display, Error as FmtError, Formatter},
     str::FromStr,
 };
-use strum_macros::EnumIter;
+use strum_macros::{Display, EnumIter};
 use time::OffsetDateTime;
 use url::Url;
 use uuid::Uuid;
@@ -111,7 +111,7 @@ impl<'de> serde::Deserialize<'de> for OwnerId {
 }
 
 /// State of an Image
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, ValueEnum, Eq)]
+#[derive(Display, Debug, Serialize, Deserialize, PartialEq, Clone, ValueEnum, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ImageState {
     /// The service has not received notification the upload has completed


### PR DESCRIPTION
Adding some other output types makes the output a little more human-friendly. See attached gif.

![freta-output-formats](https://user-images.githubusercontent.com/113544/217391395-03a31491-22e1-4fda-a595-a3439ee99699.gif)
